### PR TITLE
gpu_benchmark.cpp: Fixed excessive resource usage.

### DIFF
--- a/gpu_benchmark.cpp
+++ b/gpu_benchmark.cpp
@@ -43,6 +43,7 @@ cublasHandle_t get_blas_handle() {
 
     if(!is_initialized) {
         cublasCreate(&cublas_handle);
+        is_initialized = true;
     }
     return cublas_handle;
 }


### PR DESCRIPTION
cublasCreate() was called with each invocation of get_blas_handle() rather than once for the lifetime of the program.