### PR TITLE
Foolproof readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ Use the `--batch` option to produce less verbose output that can be easily parse
 ```bash
 # on a system with 4 GPUs per node, use all 16 GPUs on 4 nodes to
 # run GEMM with matrix dimension 10000*10000 on the GPU for 30 seconds
-srun -n16 -N4 ./burn --batch -ggemm,10000 -d30
+srun -n16 -N4 --gpus-per-task=1 ./burn --batch -ggemm,10000 -d30
 nid001272:gpu    584 iterations, 38930.92 GFlops,     30.0 seconds,    2.400 Gbytes
 nid001272:gpu    579 iterations, 38555.99 GFlops,     30.0 seconds,    2.400 Gbytes
 nid001272:gpu    561 iterations, 37348.14 GFlops,     30.0 seconds,    2.400 Gbytes


### PR DESCRIPTION
ensure different GPUs for different ranks, moves from
```
$ srun -n4 -N1 -p debug -A a-csstaff ./burn --batch -ggemm,10000 -d30
nid006460:gpu    139 iterations,  9256.94 GFlops,     30.0 seconds,    2.400 Gbytes
nid006460:gpu    139 iterations,  9258.29 GFlops,     30.0 seconds,    2.400 Gbytes
nid006460:gpu    139 iterations,  9258.23 GFlops,     30.0 seconds,    2.400 Gbytes
nid006460:gpu    139 iterations,  9258.03 GFlops,     30.0 seconds,    2.400 Gbytes
```
to
```
$ srun -n4 -N1 -p debug -A a-csstaff --gpus-per-task=1  ./burn --batch -ggemm,10000 -d30
nid006449:gpu    622 iterations, 41456.13 GFlops,     30.0 seconds,    2.400 Gbytes
nid006449:gpu    598 iterations, 39826.92 GFlops,     30.0 seconds,    2.400 Gbytes
nid006449:gpu    627 iterations, 41755.09 GFlops,     30.0 seconds,    2.400 Gbytes
nid006449:gpu    616 iterations, 41005.86 GFlops,     30.0 seconds,    2.400 Gbytes
```
```